### PR TITLE
Add price command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# vscode
+.vscode/ 

--- a/rallyrolebot/cogs/rally_cog.py
+++ b/rallyrolebot/cogs/rally_cog.py
@@ -1,7 +1,6 @@
 import json
 import sys
 import traceback
-import math
 from typing import Union
 
 import discord
@@ -14,7 +13,7 @@ import coingecko_api
 import validation
 import errors
 
-from utils import pretty_print, send_to_dm
+from utils import pretty_print, send_to_dm, get_gradient_by_percentage
 from utils.converters import CreatorCoin, CommonCoin
 from constants import *
 
@@ -44,18 +43,11 @@ class RallyCommands(commands.Cog):
 
     @commands.command(name="price", help="Get the price data of a coin")
     async def price(self, ctx, coin_symbol : Union[CreatorCoin, CommonCoin]):
-        def increase_decrease_gradient_index(percentage):
-            gradient = 5
-            if isinstance(percentage, float) and percentage != 0:
-                rank = math.floor(percentage / 20)
-                if(rank >= 5):
-                    rank = 5
-                elif(rank < -5):
-                    rank = -5
-                elif rank >= 0:
-                    rank += 1
-                gradient += rank
-            return gradient
+        def get_gradient_color(percentage):
+            if percentage < 0:
+                return get_gradient_by_percentage(str(WHITE_COLOR), str(DARK_RED_COLOR), PRICE_GRADIENT_DEPTH, abs(percentage))
+            else:
+                return get_gradient_by_percentage(str(WHITE_COLOR), str(DARK_GREEN_COLOR), PRICE_GRADIENT_DEPTH, percentage)
 
         price = coingecko_api.get_price_data(coin_symbol) or rally_api.get_price_data(coin_symbol)
 
@@ -72,13 +64,11 @@ class RallyCommands(commands.Cog):
             await pretty_print(ctx, 
                 f"{percentage_24h}%", 
                 title="24H Price Change", 
-                color=INCREASE_DECREASE_GRADIENT_COLOR[
-                    increase_decrease_gradient_index(percentage_24h)])
+                color=get_gradient_color(percentage_24h))
             await pretty_print(ctx, 
                 f"{percentage_30d}%", 
                 title="30D Price Change", 
-                color=INCREASE_DECREASE_GRADIENT_COLOR[
-                    increase_decrease_gradient_index(percentage_30d)])
+                color=get_gradient_color(percentage_30d))
 
     @commands.command(name="unset_rally_id", help="Unset your rally id")
     @commands.dm_only()

--- a/rallyrolebot/cogs/rally_cog.py
+++ b/rallyrolebot/cogs/rally_cog.py
@@ -8,6 +8,8 @@ from discord.utils import get
 
 import data
 import rally_api
+import coingecko_api
+import validation
 import errors
 
 from utils import pretty_print, send_to_dm
@@ -20,7 +22,6 @@ class RallyCommands(commands.Cog):
     async def cog_after_invoke(self, ctx):
         await pretty_print( ctx, "Command completed successfully!",  title= "Success", color=SUCCESS_COLOR)
 
-    @send_to_dm
     @errors.standard_error_handler
     async def cog_command_error(self, ctx, error):
 
@@ -32,3 +33,22 @@ class RallyCommands(commands.Cog):
     @commands.dm_only()
     async def set_rally_id(self, ctx, rally_id):
         data.add_discord_rally_mapping(ctx.author.id, rally_id)
+
+    @commands.command(name="price", help="Get the price data of a coin")
+    @validation.is_valid_coin()
+    async def price(self, ctx, coin_symbol):
+        price = coingecko_api.get_price_data(coin_symbol) or rally_api.get_price_data(coin_symbol)
+
+        dataTitle = ""
+        dataStr = ""
+
+        if price is False:
+            dataTitle = "Error"
+            dataStr = "There was an error while fetching the coin data\nPlease try again"
+        else:
+            dataTitle = f"{coin_symbol.upper()} Price Data"
+            dataStr = f"Current Price: {price['current_price']}\n\
+                24H Price Change: {price['price_change_percentage_24h']}%\n\
+                30D Price Change: {price['price_change_percentage_30d']}%"
+        
+        await pretty_print(ctx, dataStr, title=dataTitle, color=WARNING_COLOR)

--- a/rallyrolebot/cogs/rally_cog.py
+++ b/rallyrolebot/cogs/rally_cog.py
@@ -2,6 +2,7 @@ import json
 import sys
 import traceback
 import math
+from typing import Union
 
 import discord
 from discord.ext import commands, tasks
@@ -14,6 +15,7 @@ import validation
 import errors
 
 from utils import pretty_print, send_to_dm
+from utils.converters import CreatorCoin, CommonCoin
 from constants import *
 
 
@@ -41,8 +43,7 @@ class RallyCommands(commands.Cog):
         data.add_discord_rally_mapping(ctx.author.id, rally_id)
 
     @commands.command(name="price", help="Get the price data of a coin")
-    @validation.is_valid_coin()
-    async def price(self, ctx, coin_symbol):
+    async def price(self, ctx, coin_symbol : Union[CreatorCoin, CommonCoin]):
         def increase_decrease_gradient_index(percentage):
             gradient = 5
             if isinstance(percentage, float) and percentage != 0:

--- a/rallyrolebot/cogs/rally_cog.py
+++ b/rallyrolebot/cogs/rally_cog.py
@@ -63,10 +63,7 @@ class RallyCommands(commands.Cog):
         percentage_30d = price["price_change_percentage_30d"]
 
         if price is False:
-            await pretty_print(ctx, 
-                "There was an error while fetching the coin data", 
-                title="Error", 
-                color=ERROR_COLOR)
+            raise errors.RequestError("There was an error while fetching the coin data")
         else:
             await pretty_print(ctx, 
                 f"Current Price: {price['current_price']}", 

--- a/rallyrolebot/coingecko_api.py
+++ b/rallyrolebot/coingecko_api.py
@@ -1,0 +1,65 @@
+import json
+
+import requests
+
+from constants import *
+
+def get_coins_list():
+    url = COINGECKO_API_URL + "/coins/list"
+    result = requests.get(url)
+    if result.status_code != 200:
+        print("Request error!")
+        print(url)
+        print(result.status_code)
+        print(type(result.json()))
+        print(result.json())
+        return False
+
+    return result.json()
+
+def valid_coin(symbol):
+    symbol = symbol.lower()
+
+    coins = get_coins_list()
+    if coins is False:
+        return False
+
+    for keyval in coins:
+        if symbol == keyval["symbol"].lower():
+            return True
+    return False
+    
+
+def get_id_from_symbol(symbol):
+    symbol = symbol.lower()
+
+    coins = get_coins_list()
+    if coins is False:
+        return False
+    
+    for keyval in coins:
+        if symbol == keyval["symbol"].lower():
+            return keyval["id"]
+    return False
+
+def get_price_data(symbol):
+    id = get_id_from_symbol(symbol)
+    if id is False:
+        return False
+    
+    url = COINGECKO_API_URL + "/coins/" + id
+    result = requests.get(url)
+    if result.status_code != 200:
+        print("Request error!")
+        print(url)
+        print(result.status_code)
+        print(type(result.json()))
+        print(result.json())
+        return False
+        
+    result = result.json()["market_data"]
+    return {
+        "current_price": result["current_price"]["usd"],
+        "price_change_percentage_24h": result["price_change_percentage_24h"],
+        "price_change_percentage_30d": result["price_change_percentage_30d"],
+    }

--- a/rallyrolebot/coingecko_api.py
+++ b/rallyrolebot/coingecko_api.py
@@ -4,15 +4,18 @@ import requests
 
 from constants import *
 
+def returnReqError(url, result):
+    print("Request error!")
+    print(f"Url: {url}")
+    print(f"Status Code: {result.status_code}")
+    print(f"JSON result type: {type(result.json())}")
+    print(result.json())
+
 def get_coins_list():
     url = COINGECKO_API_URL + "/coins/list"
     result = requests.get(url)
     if result.status_code != 200:
-        print("Request error!")
-        print(url)
-        print(result.status_code)
-        print(type(result.json()))
-        print(result.json())
+        returnReqError(url, result)
         return False
 
     return result.json()
@@ -50,11 +53,7 @@ def get_price_data(symbol):
     url = COINGECKO_API_URL + "/coins/" + id
     result = requests.get(url)
     if result.status_code != 200:
-        print("Request error!")
-        print(url)
-        print(result.status_code)
-        print(type(result.json()))
-        print(result.json())
+        returnReqError(url, result)
         return False
         
     result = result.json()["market_data"]

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -25,6 +25,7 @@ COIN_KIND_KEY = "coinKind"
 COIN_BALANCE_KEY = "coinBalance"
 
 BASE_URL = "https://api.rally.io/v1"
+COINGECKO_API_URL = "https://api.coingecko.com/api/v3"
 
 
 """

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -40,3 +40,17 @@ UPDATE_WAIT_TIME = 600
 ERROR_COLOR =  Color(0xFF0000)
 SUCCESS_COLOR = Color(0x0000FF)
 WARNING_COLOR = Color(0xFFFF00)
+WHITE_COLOR = Color(0xFFFFFE)
+INCREASE_DECREASE_GRADIENT_COLOR = [
+    Color(0x9E1711), # Spartan Crimson
+    Color(0xB12E21), # Chinese Brown
+    Color(0xC34632), # International Orange
+    Color(0xD65D42), # Medium Vermilion
+    Color(0xE97452), # Burnt Sienna
+    WHITE_COLOR,
+    Color(0x95F985), # Light Green
+    Color(0x4DED30), # Neon Green
+    Color(0x26D701), # Harlequin Green
+    Color(0x00C301), # Vivid Malachite
+    Color(0x00AB08), # Islamic Green
+]

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -54,20 +54,10 @@ SUCCESS_COLOR = Color(0x0000FF)
 WARNING_COLOR = Color(0xFFFF00)
 GREEN_COLOR = Color(0x00FF00)
 WHITE_COLOR = Color(0xFFFFFE)
-INCREASE_DECREASE_GRADIENT_COLOR = [
-    Color(0x9E1711), # Spartan Crimson
-    Color(0xB12E21), # Chinese Brown
-    Color(0xC34632), # International Orange
-    Color(0xD65D42), # Medium Vermilion
-    Color(0xE97452), # Burnt Sienna
-    WHITE_COLOR,
-    Color(0x95F985), # Light Green
-    Color(0x4DED30), # Neon Green
-    Color(0x26D701), # Harlequin Green
-    Color(0x00C301), # Vivid Malachite
-    Color(0x00AB08), # Islamic Green
-]
+DARK_RED_COLOR = Color(0x800000)
+DARK_GREEN_COLOR = Color(0x008000)
 
+PRICE_GRADIENT_DEPTH = 5
 
 DEFAULT_DONATE_MESSAGE = "You can donate to by going to - Your donation helps grow and support the community and creator - Plus, there are 10 tiers of Donation badges to earn to show off your support!"
 DEFAULT_PURCHASE_MESSAGE = "You can purchase at by using a Credit/Debit card or a number of different Crypto Currencies! Buying earns rewards, supports the community, and you can even get VIP Status! (hint: there’s a secret VIP room for users who hold over X # of ;)"

--- a/rallyrolebot/errors.py
+++ b/rallyrolebot/errors.py
@@ -8,6 +8,15 @@ class IllegalRole(commands.CommandError):
         super().__init__( *args, **kwargs)
         self.message = message
 
+class InvalidCoin(commands.CommandError):
+    def __init__(self, message, *args, **kwargs):
+        super().__init__( *args, **kwargs)
+        self.message = message
+
+class MissingRequiredArgument(commands.CommandError):
+    def __init__(self, *args, **kwargs):
+        super().__init__( *args, **kwargs)
+
 def standard_error_handler(error_function):
     """
         Decorator that is prepended to a cog_command_error.
@@ -101,10 +110,17 @@ def standard_error_handler(error_function):
                   color=ERROR_COLOR)
             return
 
-        elif isinstance(error, commands.MissingRequiredArgument):
+        elif isinstance(error, MissingRequiredArgument or commands.MissingRequiredArgument):
             await ctx.send_help(ctx.command)
             await pretty_print(ctx,
                     "Missing required arguments",
+                    title="Error",
+                    color=ERROR_COLOR)
+            return
+
+        elif isinstance(error, InvalidCoin):
+            await pretty_print(ctx,
+                    error.message + extra ,
                     title="Error",
                     color=ERROR_COLOR)
             return

--- a/rallyrolebot/errors.py
+++ b/rallyrolebot/errors.py
@@ -20,10 +20,6 @@ class InvalidCoin(commands.CommandError):
         super().__init__( *args, **kwargs)
         self.message = message
 
-class MissingRequiredArgument(commands.CommandError):
-    def __init__(self, *args, **kwargs):
-        super().__init__( *args, **kwargs)
-
 def standard_error_handler(error_function):
     """
     Decorator that is prepended to a cog_command_error.
@@ -127,7 +123,7 @@ def standard_error_handler(error_function):
             )
             return
 
-        elif isinstance(error, MissingRequiredArgument or commands.MissingRequiredArgument):
+        elif isinstance(error, MissingRequiredArgument):
             await ctx.send_help(ctx.command)
             await pretty_print(
                 ctx, "Missing required arguments", title="Error", color=ERROR_COLOR

--- a/rallyrolebot/errors.py
+++ b/rallyrolebot/errors.py
@@ -20,6 +20,11 @@ class InvalidCoin(commands.CommandError):
         super().__init__( *args, **kwargs)
         self.message = message
 
+class RequestError(commands.CommandError):
+    def __init__(self, message, *args, **kwargs):
+        super().__init__( *args, **kwargs)
+        self.message = message
+
 def standard_error_handler(error_function):
     """
     Decorator that is prepended to a cog_command_error.
@@ -130,6 +135,16 @@ def standard_error_handler(error_function):
             )
             return
 
+        elif isinstance(error, BadUnionArgument):
+            await ctx.send_help(ctx.command)
+            await pretty_print(
+                ctx, 
+                "Invalid argument",
+                title="Error",
+                color=ERROR_COLOR,
+            )
+            return
+
         elif isinstance(error, WalletNotVerified):
             await pretty_print(ctx,
                     error.message + extra ,
@@ -144,6 +159,12 @@ def standard_error_handler(error_function):
                     color=ERROR_COLOR)
             return
 
+        elif isinstance(error, RequestError):
+            await pretty_print(ctx,
+                    error.message + extra ,
+                    title="Error",
+                    color=ERROR_COLOR)
+            return
         await error_function(cls, ctx, error)
 
     return wrapper

--- a/rallyrolebot/rally_api.py
+++ b/rallyrolebot/rally_api.py
@@ -38,10 +38,28 @@ def valid_coin_symbol(coin_name):
     url = BASE_URL + "/creator_coins/" + coin_name + "/price"
     result = requests.get(url)
     if result.status_code != 200:
+        return False
+    return result.json()["symbol"] is not None
+
+def get_current_price(coin_name):
+    url = BASE_URL + "/creator_coins/" + coin_name + "/price"
+    result = requests.get(url)
+    if result.status_code != 200:
         print("Request error!")
         print(url)
         print(result.status_code)
         print(type(result.json()))
         print(result.json())
         return False
-    return json.loads(result.json())["symbol"] is not None
+    return result.json()
+
+"""
+    TODO: Add 24h and 30d price data
+"""
+def get_price_data(coin_name):
+    data = get_current_price(coin_name)
+    return {
+        "current_price": data["priceInUSD"],
+        "price_change_percentage_24h": "N/A",
+        "price_change_percentage_30d": "N/A",
+    }

--- a/rallyrolebot/utils/__init__.py
+++ b/rallyrolebot/utils/__init__.py
@@ -1,6 +1,7 @@
 from discord import Embed, Color
 
 from utils.ext import *
+from utils.color import get_gradient_by_percentage
 
 
 # TODO: make pretty_print scalable so character limit does not matter

--- a/rallyrolebot/utils/__init__.py
+++ b/rallyrolebot/utils/__init__.py
@@ -45,4 +45,3 @@ async def pretty_print(ctx, fields, caption="", title="", color=Color(0xFFFFFF))
 
 
 
-    

--- a/rallyrolebot/utils/color.py
+++ b/rallyrolebot/utils/color.py
@@ -1,0 +1,65 @@
+from discord import Color
+
+from constants import *
+import math
+
+def make_color_tuple(color):
+    """
+    Turn something like "#000000" into 0,0,0 or "#FFFFFF" into "255,255,255"
+    """
+    R = color[1:3]
+    G = color[3:5]
+    B = color[5:7]
+
+    R = int(R, 16)
+    G = int(G, 16)
+    B = int(B, 16)
+
+    return R, G, B
+
+
+def interpolate_tuple(start_color, final_color, steps, index):
+    """
+    Take two RGB color sets and mix them over a specified number of steps and index
+    """
+    R = start_color[0]
+    G = start_color[1]
+    B = start_color[2]
+
+    target_R = final_color[0]
+    target_G = final_color[1]
+    target_B = final_color[2]
+
+    Diff_R = target_R - R
+    Diff_G = target_G - G
+    Diff_B = target_B - B
+
+    iR = R + (Diff_R * index / steps)
+    iG = G + (Diff_G * index / steps)
+    iB = B + (Diff_B * index / steps)
+
+    color = Color.from_rgb(int(iR), int(iG), int(iB))
+
+    return color
+
+
+def interpolate_color(start_color, final_color, steps, index):
+    """
+    Wrapper for interpolate_tuple that accepts colors as html ("#CCCCC" and such)
+    """
+    start_tuple = make_color_tuple(start_color)
+    final_tuple = make_color_tuple(final_color)
+
+    return interpolate_tuple(start_tuple, final_tuple, steps, index)
+
+
+def get_gradient_by_percentage(start_color, goal_color, steps, percentage):
+    """
+    Get gradient color calculated by the percentage. Dont use negative values
+    """
+    if percentage >= 100:
+        index = steps
+    else:
+        index = math.ceil(percentage / (100 / steps))
+
+    return interpolate_color(start_color, goal_color, steps, index)

--- a/rallyrolebot/utils/converters.py
+++ b/rallyrolebot/utils/converters.py
@@ -1,0 +1,19 @@
+from discord.ext import commands
+
+from rally_api import valid_coin_symbol
+from coingecko_api import valid_coin
+import errors
+
+class CommonCoin(commands.Converter):
+    async def convert(self, ctx, argument):
+        valid = valid_coin(argument)
+        if not valid:
+            raise errors.InvalidCoin("Invalid coin symbol")
+        return argument
+
+class CreatorCoin(commands.Converter):
+    async def convert(self, ctx, argument):
+        valid = valid_coin_symbol(argument)
+        if not valid:
+            raise errors.InvalidCoin("Invalid coin symbol")
+        return argument

--- a/rallyrolebot/validation.py
+++ b/rallyrolebot/validation.py
@@ -58,36 +58,7 @@ async def is_valid_channel(ctx, channel_name):
         )
         return False
     return True
-
-
-async def is_valid_creator_coin(coin_symbol):
-    valid = valid_coin_symbol(coin_symbol)
-    if not valid:
-        return False
-    return True
-
-async def is_valid_common_coin(coin_symbol):
-    valid = valid_coin(coin_symbol)
-    if not valid:
-        return False
-    return True
-
-def is_valid_coin():
-    async def extended_check(ctx):
-        if ctx.message.content == "$help":
-            return True
-
-        content = ctx.message.content.split(' ', 1)
-        if len(content) <= 1:
-            raise errors.MissingRequiredArgument()
-
-        symbol = content[1]
-        valid = await is_valid_creator_coin(symbol) or await is_valid_common_coin(symbol)
-        if not valid:
-            raise errors.InvalidCoin("Invalid coin symbol")
-        return True
-
-    return commands.check(extended_check)
+    
     
 def is_wallet_verified():
     async def extended_check(ctx):


### PR DESCRIPTION
Closes #3 

Uses coingecko api to retrieve data of OG crypto.

Since adding gradient text color is not possible(except for few options which come from code-blocks), used gradient colors in the embed message itself.

24h and 30d price changes for creator coins are missing since it is not possible to retrieve them from Rally API(if I'm not missing something). 
I'm open for suggestions on how to handle this.