### PR TITLE
Change bot name & avatar

### DIFF
--- a/rallyrolebot/api/bot_config_mappings.py
+++ b/rallyrolebot/api/bot_config_mappings.py
@@ -8,7 +8,7 @@ from .models import BotConfigMapping
 router = APIRouter(
     prefix="/mappings/bot_config",
     tags=["bot_config"],
-    dependencies=[],
+    dependencies=[Depends(owner_or_admin)],
     responses={404: {"description": "Not found"}},
 )
 

--- a/rallyrolebot/api/bot_config_mappings.py
+++ b/rallyrolebot/api/bot_config_mappings.py
@@ -1,0 +1,31 @@
+import data
+
+from fastapi import APIRouter, Depends, HTTPException
+from .dependencies import owner_or_admin
+from .models import BotConfigMapping
+
+
+router = APIRouter(
+    prefix="/mappings/bot_config",
+    tags=["bot_config"],
+    dependencies=[],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get("/{guildId}", response_model=BotConfigMapping)
+async def read_mapping(guildId: str):
+    name = data.get_bot_name(guildId)
+    if not name:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+    return {"guildId": guildId, "bot_name": name}
+
+
+@router.post("/{guildId}", response_model=BotConfigMapping)
+async def add_mapping(mapping: BotConfigMapping, guildId: str):
+    if mapping.bot_name is not None:
+      data.set_bot_name(guildId, mapping.bot_name)
+    name = data.get_bot_name(guildId)
+    if not name:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+    return {"guildId": guildId, "bot_name": name}

--- a/rallyrolebot/api/bot_globals_mappings.py
+++ b/rallyrolebot/api/bot_globals_mappings.py
@@ -1,0 +1,34 @@
+import data
+
+from fastapi import APIRouter, Depends, HTTPException
+from .dependencies import bot_owner
+from .models import BotGlobalsMapping
+
+
+router = APIRouter(
+    prefix="/mappings/bot_globals",
+    tags=["bot_globals"],
+    dependencies=[Depends(bot_owner)],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get("/", response_model=BotGlobalsMapping)
+async def read_mapping():
+    avatar_url = data.get_bot_avatar_url()
+    avatar_hash = data.get_bot_avatar_hash()
+    if not avatar_url:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+    return {"bot_avatar_url": avatar_url, "bot_avatar_hash": avatar_hash}
+
+
+@router.post("/", response_model=BotGlobalsMapping)
+async def add_mapping(mapping: BotGlobalsMapping):
+    if mapping.bot_avatar_url is not None:
+        data.set_bot_avatar(mapping.bot_avatar_url)
+        data.set_bot_avatar_hash("")
+    avatar_url = data.get_bot_avatar_url()
+    avatar_hash = data.get_bot_avatar_hash()
+    if not avatar_url:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+    return {"bot_avatar_url": avatar_url, "bot_avatar_hash": avatar_hash}

--- a/rallyrolebot/api/dependencies.py
+++ b/rallyrolebot/api/dependencies.py
@@ -48,3 +48,8 @@ async def owner_or_admin(guildId: str, authorization: str = Header(...)):
     guilds = owner_or_admin_guilds(authorization)
     if not guilds or not guildId in guilds:
         raise HTTPException(status_code=400, detail="you cannot access this record")
+
+
+async def bot_owner(authorization: str = Header(...)):
+    # TODO: Implement bot_owner check
+    raise HTTPException(status_code=400, detail="you cannot access this record")

--- a/rallyrolebot/api/models.py
+++ b/rallyrolebot/api/models.py
@@ -35,3 +35,7 @@ class Command(BaseModel):
 class BotConfigMapping(BaseModel):
     guildId: Optional[str] = None
     bot_name: str
+
+class BotGlobalsMapping(BaseModel):
+    bot_avatar_url: str
+    bot_avatar_hash: Optional[str] = ""

--- a/rallyrolebot/api/models.py
+++ b/rallyrolebot/api/models.py
@@ -31,3 +31,7 @@ class PrefixMapping(BaseModel):
 class Command(BaseModel):
     name: str
     description: str
+
+class BotConfigMapping(BaseModel):
+    guildId: Optional[str] = None
+    bot_name: str

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -8,6 +8,7 @@ from api import (
     prefix_mappings,
     coin_mappings,
     bot_config_mappings,
+    bot_globals_mappings,
     commands,
 )
 import config
@@ -35,6 +36,7 @@ app.include_router(role_mappings.router)
 app.include_router(prefix_mappings.router)
 app.include_router(coin_mappings.router)
 app.include_router(bot_config_mappings.router)
+app.include_router(bot_globals_mappings.router)
 app.include_router(commands.router)
 
 

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -7,6 +7,7 @@ from api import (
     role_mappings,
     prefix_mappings,
     coin_mappings,
+    bot_config_mappings,
     commands,
 )
 import config
@@ -33,6 +34,7 @@ app.include_router(channel_mappings.router)
 app.include_router(role_mappings.router)
 app.include_router(prefix_mappings.router)
 app.include_router(coin_mappings.router)
+app.include_router(bot_config_mappings.router)
 app.include_router(commands.router)
 
 

--- a/rallyrolebot/cogs/defaults_cog.py
+++ b/rallyrolebot/cogs/defaults_cog.py
@@ -109,3 +109,12 @@ class DefaultsCommands(commands.Cog):
             title=f"All registered users",
             color=GREEN_COLOR,
         )
+
+    @commands.command(
+        name="change_bot_name",
+        help="Change the bot's name on this server"
+    )
+    @validation.owner_or_permissions(administrator=True)
+    async def set_bot_name(self, ctx, name):
+        data.set_bot_name(ctx.guild.id, name)
+        await update_cog.force_update(self.bot, ctx)

--- a/rallyrolebot/cogs/defaults_cog.py
+++ b/rallyrolebot/cogs/defaults_cog.py
@@ -118,3 +118,14 @@ class DefaultsCommands(commands.Cog):
     async def set_bot_name(self, ctx, name):
         data.set_bot_name(ctx.guild.id, name)
         await update_cog.force_update(self.bot, ctx)
+
+    @commands.command(
+        name="change_bot_avatar",
+        help="Changes the bot's global avatar for all servers"
+    )
+    @commands.is_owner()
+    async def set_bot_avatar(self, ctx, url):
+        data.set_bot_avatar(url)
+        data.set_bot_avatar_hash("")
+        await update_cog.force_update(self.bot, ctx)
+        data.set_bot_avatar_hash(self.bot.user.avatar)

--- a/rallyrolebot/cogs/update_cog.py
+++ b/rallyrolebot/cogs/update_cog.py
@@ -14,6 +14,7 @@ import data
 import rally_api
 import validation
 
+from cogs import defaults_cog
 
 async def grant_deny_channel_to_member(channel_mapping, member, balances):
     """
@@ -171,8 +172,15 @@ class UpdateTask(commands.Cog):
 
                 try:
                     bot_avatar = data.get_bot_avatar()
+                    bot_avatar_url = data.get_bot_avatar_url()
                     bot_avatar_hash = data.get_bot_avatar_hash()
-                    if bot_avatar_hash != self.bot.user.avatar:
+                    if not bot_avatar_url:
+                        url = DEFAULT_BOT_AVATAR_URL
+                        data.set_bot_avatar(url)
+                        data.set_bot_avatar_hash("")
+                        await self.update()
+                        data.set_bot_avatar_hash(self.bot.user.avatar)
+                    elif bot_avatar_hash != self.bot.user.avatar:
                         print("Updating avatar")
                         await self.bot.user.edit(avatar=bot_avatar)
                 except discord.errors.HTTPException as e:

--- a/rallyrolebot/cogs/update_cog.py
+++ b/rallyrolebot/cogs/update_cog.py
@@ -162,8 +162,22 @@ class UpdateTask(commands.Cog):
                             )
 
                 # Update bot config
-                bot_name = data.get_bot_name(guild.id)
-                await guild.me.edit(nick=bot_name)
+                try:
+                    bot_name = data.get_bot_name(guild.id)
+                    if bot_name != guild.me.nick:
+                        await guild.me.edit(nick=bot_name)
+                except discord.errors.HTTPException as e:
+                    print("Failed to update bot's nickname:", e)
+
+                try:
+                    bot_avatar = data.get_bot_avatar()
+                    bot_avatar_hash = data.get_bot_avatar_hash()
+                    if bot_avatar_hash != self.bot.user.avatar:
+                        print("Updating avatar")
+                        await self.bot.user.edit(avatar=bot_avatar)
+                except discord.errors.HTTPException as e:
+                    print("Failed to update bot's avatar:", e)
+                    data.set_bot_avatar_hash("")
 
             print(
                 "Done! Checked "

--- a/rallyrolebot/cogs/update_cog.py
+++ b/rallyrolebot/cogs/update_cog.py
@@ -161,6 +161,10 @@ class UpdateTask(commands.Cog):
                                 channel_mapping, member, balances
                             )
 
+                # Update bot config
+                bot_name = data.get_bot_name(guild.id)
+                await guild.me.edit(nick=bot_name)
+
             print(
                 "Done! Checked "
                 + str(guild_count)

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -78,6 +78,7 @@ PRICE_GRADIENT_DEPTH = 5
 
 DEFAULT_DONATE_MESSAGE = "You can donate to by going to - Your donation helps grow and support the community and creator - Plus, there are 10 tiers of Donation badges to earn to show off your support!"
 DEFAULT_PURCHASE_MESSAGE = "You can purchase at by using a Credit/Debit card or a number of different Crypto Currencies! Buying earns rewards, supports the community, and you can even get VIP Status! (hint: there’s a secret VIP room for users who hold over X # of ;)"
+DEFAULT_BOT_AVATAR_URL = "https://rallybot.app/img/space.5424f731.png"
 
 API_TAGS_METADATA = [
     {"name": "channels", "description": "Coin channel mappings"},
@@ -86,4 +87,5 @@ API_TAGS_METADATA = [
     {"name": "prefix", "description": "Command prefix in guild"},
     {"name": "roles", "description": "Coin role mappings"},
     {"name": "bot_config", "description": "Guild specific bot configuration"},
+    {"name": "bot_globals", "description": "Global bot configuration"},
 ]

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -39,6 +39,7 @@ CONFIG_NAME_KEY = "configName"
 PURCHASE_MESSAGE_KEY = "purchaseMessage"
 DONATE_MESSAGE_KEY = "donateMessage"
 
+BOT_NAME_KEY = "bot_name"
 
 """
  Constants useful for  rally_api module
@@ -81,4 +82,5 @@ API_TAGS_METADATA = [
     {"name": "commands", "description": "Get list of all available bot commands"},
     {"name": "prefix", "description": "Command prefix in guild"},
     {"name": "roles", "description": "Coin role mappings"},
+    {"name": "bot_config", "description": "Guild specific bot configuration"},
 ]

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -40,6 +40,9 @@ PURCHASE_MESSAGE_KEY = "purchaseMessage"
 DONATE_MESSAGE_KEY = "donateMessage"
 
 BOT_NAME_KEY = "bot_name"
+BOT_AVATAR_KEY = "bot_avatar"
+BOT_AVATAR_URL_KEY = "bot_avatar_url"
+BOT_AVATAR_HASH_KEY = "bot_avatar_hash"
 
 """
  Constants useful for  rally_api module

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -249,6 +249,27 @@ def get_donate_message(db, guild_id):
 
 
 @connect_db
+def set_bot_name(db, guild_id, name):
+    table = db[CONFIG_TABLE]
+    table.upsert(
+        {
+            GUILD_ID_KEY: guild_id,
+            BOT_NAME_KEY: name,
+            CONFIG_NAME_KEY: BOT_NAME_KEY
+        },
+        [GUILD_ID_KEY, CONFIG_NAME_KEY],
+    )
+
+@connect_db
+def get_bot_name(db, guild_id):
+    table = db[CONFIG_TABLE]
+    row = table.find_one(guildId=guild_id, configName=BOT_NAME_KEY)
+    if row is not None:
+        return row[BOT_NAME_KEY]
+    return None
+
+
+@connect_db
 def add_user(db, discord_id, username, discriminator, guilds):
     table = db[USERS_TABLE]
     table.upsert(

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -1,5 +1,6 @@
 import dataset
 import datetime
+import urllib
 
 import config
 from constants import *
@@ -266,6 +267,70 @@ def get_bot_name(db, guild_id):
     row = table.find_one(guildId=guild_id, configName=BOT_NAME_KEY)
     if row is not None:
         return row[BOT_NAME_KEY]
+    return None
+
+
+@connect_db
+def set_bot_avatar(db, url):
+    try:
+        response = urllib.request.urlopen(url)
+
+        table = db[CONFIG_TABLE]
+        table.upsert(
+            {
+                BOT_AVATAR_KEY: response.read(),
+                CONFIG_NAME_KEY: BOT_AVATAR_KEY
+            },
+            [CONFIG_NAME_KEY],
+        )
+        table.upsert(
+            {
+                BOT_AVATAR_URL_KEY: url,
+                CONFIG_NAME_KEY: BOT_AVATAR_URL_KEY
+            },
+            [CONFIG_NAME_KEY],
+        )
+
+    except urllib.error.HTTPError as e:
+        raise Exception("Failed to download avatar") from e
+
+
+@connect_db
+def get_bot_avatar(db):
+    table = db[CONFIG_TABLE]
+    row = table.find_one(configName=BOT_AVATAR_KEY)
+    if row is not None:
+        return row[BOT_AVATAR_KEY]
+    return None
+
+
+@connect_db
+def get_bot_avatar_url(db):
+    table = db[CONFIG_TABLE]
+    row = table.find_one(configName=BOT_AVATAR_URL_KEY)
+    if row is not None:
+        return row[BOT_AVATAR_URL_KEY]
+    return None
+
+
+@connect_db
+def set_bot_avatar_hash(db, hash):
+    table = db[CONFIG_TABLE]
+    table.upsert(
+        {
+            BOT_AVATAR_HASH_KEY: hash,
+            CONFIG_NAME_KEY: BOT_AVATAR_HASH_KEY
+        },
+        [CONFIG_NAME_KEY],
+    )
+
+
+@connect_db
+def get_bot_avatar_hash(db):
+    table = db[CONFIG_TABLE]
+    row = table.find_one(configName=BOT_AVATAR_HASH_KEY)
+    if row is not None:
+        return row[BOT_AVATAR_HASH_KEY]
     return None
 
 


### PR DESCRIPTION
I added bot commands and api endpoint to change the bot's nickname per guild. It's not possible to change the bot's avatar per guild, however. For that I've added a global command and api endpoint that only the owner of the bot can execute.

I've added the bot owner check to the `change_bot_avatar` command but for the api endpoint `/mappings/bot_globals`, I've added a dependency called `bot_owner` with a `TODO` comment, which always denies access for now.

I've also added the Rally logo as a default avatar.

Issue #16 