### PR TITLE
Price cache

### DIFF
--- a/rallyrolebot/api/models.py
+++ b/rallyrolebot/api/models.py
@@ -31,3 +31,10 @@ class PrefixMapping(BaseModel):
 class Command(BaseModel):
     name: str
     description: str
+
+
+class CoinPrice(BaseModel):
+    timeCreated: Optional[str] = None
+    coinKind: Optional[str] = None
+    priceInUsd: Optional[str] = None
+    usd_24h_change: Optional[str] = None

--- a/rallyrolebot/api/models.py
+++ b/rallyrolebot/api/models.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -34,7 +35,13 @@ class Command(BaseModel):
 
 
 class CoinPrice(BaseModel):
-    timeCreated: Optional[str] = None
-    coinKind: Optional[str] = None
-    priceInUsd: Optional[str] = None
+    coinKind: str
+    priceInUSD: str
     usd_24h_change: Optional[str] = None
+
+
+class CoinPrices(BaseModel):
+    id: Optional[int] = None
+    timeCreated: datetime
+    coinKind: str
+    priceInUSD: str

--- a/rallyrolebot/api/price_data.py
+++ b/rallyrolebot/api/price_data.py
@@ -1,0 +1,37 @@
+import data
+import rally_api
+
+from typing import List, Optional
+from fastapi import APIRouter, Query
+from .models import CoinPrice
+
+
+router = APIRouter(prefix="/coins", tags=["coins"])
+
+
+@router.get("/{coin}/price", response_model=CoinPrice)
+async def read_price(coin: str, include_24hr_change: Optional[bool] = False):
+    price = rally_api.get_current_price(coin)
+    if not include_24hr_change:
+        return {"coinKind": coin, "priceInUsd": price["priceInUsd"]}
+    last_24hr = data.get_coin_prices(coin, limit=24)
+    percentage_24h_change = (
+        (price["priceInUsd"] - last_24hr[-1]["price"]) / last_24hr[-1]["price"]
+    ) * 100
+    return {
+        "coinKind": coin,
+        "priceInUsd": price["priceInUsd"],
+        "usd_24h_change": percentage_24h_change,
+    }
+
+
+@router.get("/{coin}/historical_price", response_model=List[CoinPrice])
+async def read_prices(
+    coin: str,
+    limit: Optional[int] = Query(
+        None,
+        title="Query string",
+        description="Maximum number of data points to return",
+    ),
+):
+    return [prices for prices in data.get_coin_prices(coin, limit)]

--- a/rallyrolebot/api/price_data.py
+++ b/rallyrolebot/api/price_data.py
@@ -16,12 +16,12 @@ async def read_price(coin: str, include_24hr_change: Optional[bool] = False):
         return {"coinKind": coin, "priceInUsd": price["priceInUsd"]}
     last_24hr = data.get_coin_prices(coin, limit=24)
     percentage_24h_change = (
-        (price["priceInUsd"] - last_24hr[-1]["price"]) / last_24hr[-1]["price"]
+        (float(price["priceInUsd"]) - float(last_24hr[-1]["price"])) / float(last_24hr[-1]["price"])
     ) * 100
     return {
         "coinKind": coin,
-        "priceInUsd": price["priceInUsd"],
-        "usd_24h_change": percentage_24h_change,
+        "priceInUsd": str(price["priceInUsd"]),
+        "usd_24h_change": str(percentage_24h_change),
     }
 
 

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -60,7 +60,7 @@ def get_prices():
         try:
             symbol = coin["coinSymbol"]
             price = rally_api.get_current_price(symbol)
-            data.add_coin_price(price["priceInUsd"], symbol)
+            data.add_coin_price(str(price["priceInUsd"]), symbol)
         except:
             print(f"Failed to get price for {coin['coinSymbol']}")
     print("Price data updated")

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -60,7 +60,7 @@ def get_prices():
         try:
             symbol = coin["coinSymbol"]
             price = rally_api.get_current_price(symbol)
-            data.add_coin_price(str(price["priceInUsd"]), symbol)
+            data.add_coin_price(str(price["priceInUSD"]), symbol)
         except:
             print(f"Failed to get price for {coin['coinSymbol']}")
     print("Price data updated")

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -1,19 +1,26 @@
 import uvicorn
 
+import logging
+import time
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from utils.tasks import repeat_every
 from api import (
     channel_mappings,
     role_mappings,
     prefix_mappings,
     coin_mappings,
     commands,
+    price_data,
 )
+
 import config
+import data
+import rally_api
 
 from constants import *
 
-
+logger = logging.getLogger(__name__)
 app = FastAPI(
     title="Rally Discord Bot API",
     description="API for communicating with the Rally Role Bot for Discord",
@@ -34,6 +41,7 @@ app.include_router(role_mappings.router)
 app.include_router(prefix_mappings.router)
 app.include_router(coin_mappings.router)
 app.include_router(commands.router)
+app.include_router(price_data.router)
 
 
 @app.get("/")
@@ -42,6 +50,20 @@ async def root():
         "bot": "Welcome to rally discord bot api",
         "docs": "api documentation at /docs or /redoc",
     }
+
+
+@app.on_event("startup")
+@repeat_every(seconds=60 * 60, logger=logger)
+def get_prices():
+    coins = rally_api.get_creator_coins()
+    for coin in coins:
+        try:
+            symbol = coin["coinSymbol"]
+            price = rally_api.get_current_price(symbol)
+            data.add_coin_price(price["priceInUsd"], symbol)
+        except:
+            print(f"Failed to get price for {coin['coinSymbol']}")
+    print("Price data updated")
 
 
 if __name__ == "__main__":

--- a/rallyrolebot/app.py
+++ b/rallyrolebot/app.py
@@ -20,6 +20,7 @@ import rally_api
 
 from constants import *
 
+config.parse_args()
 logger = logging.getLogger(__name__)
 app = FastAPI(
     title="Rally Discord Bot API",
@@ -63,9 +64,13 @@ def get_prices():
             data.add_coin_price(str(price["priceInUSD"]), symbol)
         except:
             print(f"Failed to get price for {coin['coinSymbol']}")
-    print("Price data updated")
+    count = data.price_count()
+    max = int(config.CONFIG.cache_max)
+    print(f"Price cache updated, Count: {count}, Max: {max}")
+    if count > max:
+        data.clean_price_cache(count - max)
+        print(f"{count - max} cache entries removed")
 
 
 if __name__ == "__main__":
-    config.parse_args()
     uvicorn.run("app:app", host=config.CONFIG.host, port=int(config.CONFIG.port))

--- a/rallyrolebot/cogs/channel_cog.py
+++ b/rallyrolebot/cogs/channel_cog.py
@@ -105,13 +105,15 @@ class ChannelCommands(commands.Cog):
     @commands.command(name="get_channel_mappings", help="Get channel mappings")
     @validation.owner_or_permissions(administrator=True)
     async def get_channel_mappings(self, ctx):
-        await ctx.send(
-            json.dumps(
-                [
-                    json.dumps(mapping)
-                    for mapping in data.get_channel_mappings(ctx.guild.id)
-                ]
-            )
+        mappingsStr = "```Channel   Coin   Amount\n\n"
+        for mapping in data.get_channel_mappings(ctx.guild.id):
+            mappingsStr += f"{mapping[CHANNEL_NAME_KEY]}   {mapping[COIN_KIND_KEY]}   {mapping[REQUIRED_BALANCE_KEY]}\n"
+        mappingsStr += "```"
+        await pretty_print(
+            ctx,
+            mappingsStr,
+            title=f"Role mappings",
+            color=GREEN_COLOR,
         )
 
     @commands.command(name="set_purchase_message", help="Change the $purchase message")

--- a/rallyrolebot/cogs/defaults_cog.py
+++ b/rallyrolebot/cogs/defaults_cog.py
@@ -102,10 +102,11 @@ class DefaultsCommands(commands.Cog):
         registered_users = data.get_all_users()
         for user in registered_users:
             member = await ctx.guild.fetch_member(user[DISCORD_ID_KEY])
-            usersStr += f"{member}\nRallyId: {user[RALLY_ID_KEY]}\nDiscordId: {user[DISCORD_ID_KEY]}\n\n"
+            if member:
+                usersStr += f"{member}\nRallyId: {user[RALLY_ID_KEY]}\nDiscordId: {user[DISCORD_ID_KEY]}\n\n"
         await pretty_print(
             ctx,
-            usersStr,
+            usersStr or "No registered users on this server",
             title=f"All registered users",
             color=GREEN_COLOR,
         )

--- a/rallyrolebot/cogs/rally_cog.py
+++ b/rallyrolebot/cogs/rally_cog.py
@@ -87,11 +87,3 @@ class RallyCommands(commands.Cog):
     @commands.dm_only()
     async def unset_rally_id(self, ctx, rally_id):
         data.remove_discord_rally_mapping(ctx.author.id, rally_id)
-
-    @commands.command(
-        name="admin_unset_rally_id",
-        help=" <discord ID> <rally ID> Unset rally ID to discord ID mapping",
-    )
-    @validation.owner_or_permissions(administrator=True)
-    async def admin_unset_rally_id(self, ctx, discord_id: discord.User, rally_id):
-        data.remove_discord_rally_mapping(discord_id, rally_id)

--- a/rallyrolebot/cogs/role_cog.py
+++ b/rallyrolebot/cogs/role_cog.py
@@ -86,11 +86,13 @@ class RoleCommands(commands.Cog):
     @commands.command(name="get_role_mappings", help="Get role mappings")
     @validation.owner_or_permissions(administrator=True)
     async def get_role_mappings(self, ctx):
-        await ctx.send(
-            json.dumps(
-                [
-                    json.dumps(mapping)
-                    for mapping in data.get_role_mappings(ctx.guild.id)
-                ]
-            )
+        mappingsStr = "```Role   Coin   Amount\n\n"
+        for mapping in data.get_role_mappings(ctx.guild.id):
+            mappingsStr += f"{mapping[ROLE_NAME_KEY]}   {mapping[COIN_KIND_KEY]}   {mapping[REQUIRED_BALANCE_KEY]}\n"
+        mappingsStr += "```"
+        await pretty_print(
+            ctx,
+            mappingsStr,
+            title=f"Role mappings",
+            color=GREEN_COLOR,
         )

--- a/rallyrolebot/config.py
+++ b/rallyrolebot/config.py
@@ -23,6 +23,8 @@ arg_parser.add("--host", default="127.0.0.1", help="Bind socket to this host")
 
 arg_parser.add("--port", default="8000", help="Bind socket to this port")
 
+arg_parser.add("--cache_max", default="2500", help="Maximun entries to store in cache")
+
 
 def parse_args():
     global CONFIG

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -19,7 +19,7 @@ COIN_PRICE_TABLE = "coin_price"
 
 
 GUILD_ID_KEY = "guildId"
-PRICE_KEY = "priceInUsd"
+PRICE_KEY = "priceInUSD"
 REQUIRED_BALANCE_KEY = "requiredBalance"
 ROLE_NAME_KEY = "roleName"
 CHANNEL_NAME_KEY = "channel"

--- a/rallyrolebot/constants.py
+++ b/rallyrolebot/constants.py
@@ -15,10 +15,11 @@ CONFIG_TABLE = "config"
 USERS_TABLE = "users"
 USERS_TOKEN_TABLE = "users_token"
 COMMANDS_TABLE = "commands"
+COIN_PRICE_TABLE = "coin_price"
 
 
 GUILD_ID_KEY = "guildId"
-COIN_KIND_KEY = "coinKind"
+PRICE_KEY = "priceInUsd"
 REQUIRED_BALANCE_KEY = "requiredBalance"
 ROLE_NAME_KEY = "roleName"
 CHANNEL_NAME_KEY = "channel"
@@ -81,4 +82,5 @@ API_TAGS_METADATA = [
     {"name": "commands", "description": "Get list of all available bot commands"},
     {"name": "prefix", "description": "Command prefix in guild"},
     {"name": "roles", "description": "Coin role mappings"},
+    {"name": "coins", "description": "Coin price data"},
 ]

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -323,13 +323,12 @@ def get_all_commands(db):
 @connect_db
 def add_coin_price(db, price, coin):
     table = db[COIN_PRICE_TABLE]
-    table.upsert(
+    table.insert(
         {
             TIME_CREATED_KEY: datetime.datetime.now(),
             PRICE_KEY: price,
             COIN_KIND_KEY: coin,
-        },
-        [TIME_CREATED_KEY, PRICE_KEY, COIN_KIND_KEY],
+        }
     )
 
 
@@ -337,4 +336,4 @@ def add_coin_price(db, price, coin):
 def get_coin_prices(db, coin, limit):
     limit = limit or 50
     table = db[COIN_PRICE_TABLE]
-    return table.find(coinKind=coin, _limit=limit, order_by=TIME_CREATED_KEY)
+    return table.find(coinKind=coin, _limit=limit, order_by="-id")

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -321,6 +321,12 @@ def get_all_commands(db):
 
 
 @connect_db
+def delete_all_commands(db):
+    table = db[COMMANDS_TABLE]
+    table.delete()
+
+
+@connect_db
 def add_coin_price(db, price, coin):
     table = db[COIN_PRICE_TABLE]
     table.insert(

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -330,6 +330,12 @@ def add_coin_price(db, price, coin):
             COIN_KIND_KEY: coin,
         }
     )
+    
+    
+@connect_db
+def add_coin_price_multiple(db, prices):
+    table = db[COIN_PRICE_TABLE]
+    table.insert_many(prices)
 
 
 @connect_db

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -31,7 +31,7 @@ from utils.ext import connect_db
     
     #################### default_coin ######################
     guildId
-    coin
+    coinKind
 
     #################### server_config ####################
     purchaseMessage
@@ -51,6 +51,11 @@ from utils.ext import connect_db
     #################### commands ####################
     name
     description
+    
+    #################### coin_price #################
+    date
+    price
+    coinKind
 
 """
 
@@ -313,3 +318,23 @@ def add_command(db, name, description):
 def get_all_commands(db):
     table = db[COMMANDS_TABLE]
     return table.all()
+
+
+@connect_db
+def add_coin_price(db, price, coin):
+    table = db[COIN_PRICE_TABLE]
+    table.upsert(
+        {
+            TIME_CREATED_KEY: datetime.datetime.now(),
+            PRICE_KEY: price,
+            COIN_KIND_KEY: coin,
+        },
+        [TIME_CREATED_KEY, PRICE_KEY, COIN_KIND_KEY],
+    )
+
+
+@connect_db
+def get_coin_prices(db, coin, limit):
+    limit = limit or 50
+    table = db[COIN_PRICE_TABLE]
+    return table.find(coinKind=coin, _limit=limit, order_by=TIME_CREATED_KEY)

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -336,8 +336,8 @@ def add_coin_price(db, price, coin):
             COIN_KIND_KEY: coin,
         }
     )
-    
-    
+
+
 @connect_db
 def add_coin_price_multiple(db, prices):
     table = db[COIN_PRICE_TABLE]
@@ -346,6 +346,12 @@ def add_coin_price_multiple(db, prices):
 
 @connect_db
 def get_coin_prices(db, coin, limit):
-    limit = limit or 50
+    limit = limit or 24
     table = db[COIN_PRICE_TABLE]
-    return table.find(coinKind=coin, _limit=limit, order_by="-id")
+    return table.find(coinKind=coin, order_by="-id", _limit=limit)
+
+
+@connect_db
+def get_last_24h_price(db, coin):
+    table = db[COIN_PRICE_TABLE]
+    return list(table.find(coinKind=coin, order_by="-id", _limit=24))[-1]

--- a/rallyrolebot/data.py
+++ b/rallyrolebot/data.py
@@ -345,6 +345,20 @@ def add_coin_price_multiple(db, prices):
 
 
 @connect_db
+def clean_price_cache(db, limit):
+    table = db[COIN_PRICE_TABLE]
+    old = table.all(order_by="id", _limit=limit)
+    for price in old:
+        table.delete(id=price["id"])
+
+
+@connect_db
+def price_count(db):
+    table = db[COIN_PRICE_TABLE]
+    return table.__len__()
+
+
+@connect_db
 def get_coin_prices(db, coin, limit):
     limit = limit or 24
     table = db[COIN_PRICE_TABLE]

--- a/rallyrolebot/main.py
+++ b/rallyrolebot/main.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
     bot.add_cog(defaults_cog.DefaultsCommands(bot))
     bot.add_cog(update_cog.UpdateTask(bot))
 
+    data.delete_all_commands()
     for command in bot.commands:
         data.add_command(command.name, command.help)
 

--- a/rallyrolebot/rally_api.py
+++ b/rallyrolebot/rally_api.py
@@ -57,6 +57,15 @@ def get_current_price(coin_name):
     return result.json()
 
 
+def get_creator_coins():
+    url = BASE_URL + "/creator_coins"
+    result = requests.get(url)
+    if result.status_code != 200:
+        returnReqError(url, result)
+        return False
+    return result.json()
+
+
 """
     TODO: Add 24h and 30d price data
 """

--- a/rallyrolebot/utils/tasks.py
+++ b/rallyrolebot/utils/tasks.py
@@ -1,0 +1,82 @@
+# tasks.py from https://github.com/dmontagu/fastapi-utils
+import asyncio
+import logging
+from asyncio import ensure_future
+from functools import wraps
+from traceback import format_exception
+from typing import Any, Callable, Coroutine, Optional, Union
+
+from starlette.concurrency import run_in_threadpool
+
+
+NoArgsNoReturnFuncT = Callable[[], None]
+NoArgsNoReturnAsyncFuncT = Callable[[], Coroutine[Any, Any, None]]
+NoArgsNoReturnDecorator = Callable[
+    [Union[NoArgsNoReturnFuncT, NoArgsNoReturnAsyncFuncT]], NoArgsNoReturnAsyncFuncT
+]
+
+
+def repeat_every(
+    *,
+    seconds: float,
+    wait_first: bool = False,
+    logger: Optional[logging.Logger] = None,
+    raise_exceptions: bool = False,
+    max_repetitions: Optional[int] = None
+) -> NoArgsNoReturnDecorator:
+    """
+    Returns decorator that modifies a function to be run periodically after it's first call
+
+    Parameters
+    ----------
+    seconds: float
+        Repeat every x seconds
+    wait_first: bool (default False)
+        Wait before executing first call
+    logger: Optional[logging.Logger] (default None)
+        log any exceptions raised
+    raise_exceptions: bool (default False)
+        Only use if you want periodic execution to stop if there's an exception.
+        Errors raised by the deecorated function will be raised to the  event loops exception handler.
+    max_repetitions: Optional[int] (default None)
+        Max number of times to repeat function, otherwise run forever
+    """
+
+    def decorator(
+        func: Union[NoArgsNoReturnAsyncFuncT, NoArgsNoReturnFuncT]
+    ) -> NoArgsNoReturnAsyncFuncT:
+        """
+        Convert decorated function to repeated function
+        """
+        is_coroutine = asyncio.iscoroutinefunction(func)
+
+        @wraps(func)
+        async def wrapped() -> None:
+            repetitions = 0
+
+            async def loop() -> None:
+                nonlocal repetitions
+                if wait_first:
+                    await asyncio.sleep(seconds)
+                while max_repetitions is None or repetitions < max_repetitions:
+                    try:
+                        if is_coroutine:
+                            await func()
+                        else:
+                            await run_in_threadpool(func)
+                        repetitions += 1
+                    except Exception as exc:
+                        if logger is not None:
+                            formatted_exception = "".join(
+                                format_exception(type(exc), exc, exc.__traceback__)
+                            )
+                            logger.error(formatted_exception)
+                        if raise_exceptions:
+                            raise exc
+                    await asyncio.sleep(seconds)
+
+            ensure_future(loop())
+
+        return wrapped
+
+    return decorator


### PR DESCRIPTION
Framework for caching data from rally api:
* repeating tasks decorator
* hourly price caching task
* `/coins/{coin}/price` endpoint for price with <24hr change
* `/coins/{coin}/historical_price` endpoint for cached price data
* use pretty_print on `get_role_mappings` and `get_channel_mappings`